### PR TITLE
Adds step where deposit refund takes place

### DIFF
--- a/products/proof-of-humanity/proof-of-humanity-tutorial.md
+++ b/products/proof-of-humanity/proof-of-humanity-tutorial.md
@@ -163,7 +163,7 @@ Vouching for someone is a benevolent act to help them get into the registry. Cur
 
 ![](../../.gitbook/assets/image%20%2868%29.png)
 
-* Once the transaction is validated, you will be in "Registered" status, accruing UBI and you will have the capacity to vouch for other people.
+* Once the transaction is validated, you will be in "Registered" status, accruing UBI and you will have the capacity to vouch for other people. Your deposit will also be refunded at this time.
 
 ![](../../.gitbook/assets/image%20%2821%29%20%281%29%20%281%29%20%281%29.png)
 


### PR DESCRIPTION
A few new users (including myself) have not understood when the deposit was actually refunded.

This PR adds a single line to explain the stage at which the deposit is refunded. 
Further questions about the deposit refund can be included in the FAQ.

Can someone from the team please confirm how deposit refund works when the deposit has been crowdfunded?