### PR TITLE
Remove Broken Link 

### DIFF
--- a/integrations/analytics.md
+++ b/integrations/analytics.md
@@ -7,7 +7,6 @@ description: Community-led resources enabling the data analysis of Kleros smart 
 ## Explorers
 
 * [Kleros Board](http://klerosboard.com/): Exhaustive Kleros Court Explorer made by the community
-* [Kleros Explorer](https://klerosexplorer.com/): Intermediary Kleros Case Explorer made by the community
 * [Kleros DB](https://klerosdb.eth.link/): Graph protocol-based Case and Court Explorer made by the community
 
 ## Data


### PR DESCRIPTION
## Description
The Kleros Explorer domain has not been renewed so the recourse is not available. This PR removes the broken link.

## Screenshots

![Screen Shot 2021-08-31 at 2 22 39 pm](https://user-images.githubusercontent.com/23159604/131441435-c5c1bef0-a41a-4fff-b7ef-3ef0add83b13.png)

_webpage showing that the domain was not renewed_